### PR TITLE
Refactor Streamlit layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Run the web interface with:
 ```bash
 streamlit run streamlit_app.py
 ```
+The controls are now located in the sidebar.
 
 ### Collision Detection
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,63 +1,100 @@
 import streamlit as st
 import matplotlib.pyplot as plt
+import numpy as np
+
 from simulation import setup_solver, animate_simulation, plot_kinetic_energy
+from utils.ui_state import init_state
 
-st.title("Particle Simulation")
+canvas_slot = st.empty()
 
-st.sidebar.header("Simulation Parameters")
 
-n_particles = st.sidebar.slider("Number of particles", min_value=1, max_value=50, value=10)
-bounding_box_radius = st.sidebar.slider("Bounding box radius", min_value=10, max_value=100, value=50)
-sim_time = st.sidebar.number_input("Simulation time (s)", min_value=1.0, max_value=20.0, value=5.0)
-substeps = st.sidebar.number_input("Substeps", min_value=10.0, max_value=2000.0, value=800.0)
-frame_skip = st.sidebar.number_input(
-    "Display every n-th frame", min_value=1, max_value=50, value=1, step=1
-)
+def build_sidebar():
+    """Return a dictionary with sidebar widget values."""
+    st.sidebar.header("Simulation Parameters")
+    ui = {
+        "n_particles": st.sidebar.slider(
+            "Number of particles", min_value=1, max_value=50, value=10
+        ),
+        "bounding_box_radius": st.sidebar.slider(
+            "Bounding box radius", min_value=10, max_value=100, value=50
+        ),
+        "sim_time": st.sidebar.number_input(
+            "Simulation time (s)", min_value=1.0, max_value=20.0, value=5.0
+        ),
+        "substeps": st.sidebar.number_input(
+            "Substeps", min_value=10.0, max_value=2000.0, value=800.0
+        ),
+        "frame_skip": st.sidebar.number_input(
+            "Display every n-th frame", min_value=1, max_value=50, value=1, step=1
+        ),
+        "run": st.sidebar.button("Run Simulation"),
+        "live": st.sidebar.button("Live Demo"),
+    }
+    return ui
 
-run = st.sidebar.button("Run Simulation")
-live = st.sidebar.button("Live Demo")
 
-if run:
-    solver = setup_solver(n_particles, bounding_box_radius, sim_time, substeps)
-    results = solver.run_simulation(sim_time, substeps)
-    animation, kinetic = animate_simulation(results, bounding_box_radius, sim_time, substeps)
-    kinetic_fig = plot_kinetic_energy(kinetic)
+def main():
+    st.title("Particle Simulation")
+    init_state()
+    ui = build_sidebar()
 
-    st.subheader("Animation")
-    html_anim = animation.to_html5_video()
-    st.components.v1.html(html_anim, height=500)
-    html_anim = animation.to_jshtml()
-    st.components.v1.html(html_anim, height=400)
+    if ui["run"]:
+        st.session_state["solver"] = setup_solver(
+            ui["n_particles"], ui["bounding_box_radius"], ui["sim_time"], ui["substeps"]
+        )
+        results = st.session_state["solver"].run_simulation(
+            ui["sim_time"], ui["substeps"]
+        )
+        animation, kinetic = animate_simulation(
+            results, ui["bounding_box_radius"], ui["sim_time"], ui["substeps"]
+        )
+        kinetic_fig = plot_kinetic_energy(kinetic)
 
-    st.subheader("Kinetic Energy")
-    st.pyplot(kinetic_fig)
+        st.subheader("Animation")
+        html_anim = animation.to_html5_video()
+        st.components.v1.html(html_anim, height=500)
+        html_anim = animation.to_jshtml()
+        st.components.v1.html(html_anim, height=400)
 
-if live:
-    solver = setup_solver(n_particles, bounding_box_radius, sim_time, substeps)
-    placeholder = st.empty()
-    progress = st.progress(0.0)
+        st.subheader("Kinetic Energy")
+        st.pyplot(kinetic_fig)
 
-    fig, ax = plt.subplots(figsize=(5, 5))
-    ax.set_aspect("equal")
-    ax.set_facecolor("darkgray")
-    circle = plt.Circle((0, 0), bounding_box_radius,
-                        edgecolor="black",
-                        facecolor="white",
-                        fill=True)
-    ax.add_patch(circle)
-    fig.canvas.draw()
-    px_per_scale = (ax.get_window_extent().width /
-                    (2 * bounding_box_radius + 2) * 72.0 / fig.dpi)
-    scatter = ax.scatter([], [], cmap="gist_rainbow",
-                         edgecolors="white", linewidth=0)
+    if ui["live"]:
+        st.session_state["solver"] = setup_solver(
+            ui["n_particles"], ui["bounding_box_radius"], ui["sim_time"], ui["substeps"]
+        )
+        placeholder = canvas_slot
+        progress = st.progress(0.0)
 
-    for step, (_, data) in enumerate(
-            solver.run_simulation_iter(sim_time, int(substeps))):
-        particles = np.vstack(data)
-        if step % int(frame_skip) == 0:
-            scatter.set_offsets(particles[:, :2])
-            scatter.set_array(np.linalg.norm(particles[:, 6:8], axis=1))
-            scatter.set_sizes((px_per_scale * 2 * particles[:, 7]) ** 2)
-            placeholder.pyplot(fig)
-        progress.progress((step + 1) / substeps)
-    plt.close(fig)
+        fig, ax = plt.subplots(figsize=(5, 5))
+        ax.set_aspect("equal")
+        ax.set_facecolor("darkgray")
+        circle = plt.Circle(
+            (0, 0),
+            ui["bounding_box_radius"],
+            edgecolor="black",
+            facecolor="white",
+            fill=True,
+        )
+        ax.add_patch(circle)
+        fig.canvas.draw()
+        px_per_scale = (
+            ax.get_window_extent().width / (2 * ui["bounding_box_radius"] + 2) * 72.0 / fig.dpi
+        )
+        scatter = ax.scatter([], [], cmap="gist_rainbow", edgecolors="white", linewidth=0)
+
+        for step, (_, data) in enumerate(
+            st.session_state["solver"].run_simulation_iter(ui["sim_time"], int(ui["substeps"]))
+        ):
+            particles = np.vstack(data)
+            if step % int(ui["frame_skip"]) == 0:
+                scatter.set_offsets(particles[:, :2])
+                scatter.set_array(np.linalg.norm(particles[:, 6:8], axis=1))
+                scatter.set_sizes((px_per_scale * 2 * particles[:, 7]) ** 2)
+                placeholder.pyplot(fig)
+            progress.progress((step + 1) / ui["substeps"])
+        plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -1,0 +1,23 @@
+import streamlit as st
+
+from utils.ui_state import init_state, reset_state, toggle_running
+
+
+def test_init_state():
+    st.session_state.clear()
+    init_state()
+    assert st.session_state['running'] is False
+    assert st.session_state['solver'] is None
+
+
+def test_toggle_and_reset():
+    st.session_state.clear()
+    init_state()
+    toggle_running()
+    assert st.session_state['running'] is True
+    toggle_running()
+    assert st.session_state['running'] is False
+    st.session_state['solver'] = object()
+    reset_state()
+    assert st.session_state['solver'] is None
+    assert st.session_state['running'] is False

--- a/utils/ui_state.py
+++ b/utils/ui_state.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+
+def init_state():
+    """Initialize session_state variables used by the UI."""
+    st.session_state.setdefault("running", False)
+    st.session_state.setdefault("solver", None)
+
+
+def reset_state():
+    """Reset solver and running flag."""
+    st.session_state["solver"] = None
+    st.session_state["running"] = False
+
+
+def toggle_running():
+    """Toggle the running flag."""
+    st.session_state["running"] = not st.session_state.get("running", False)


### PR DESCRIPTION
## Summary
- move controls to Streamlit sidebar
- keep solver in `st.session_state`
- provide `ui_state` helpers and tests
- note sidebar usage in README

## Testing
- `pytest -q`
- `streamlit run streamlit_app.py` *(fails to detect external IP but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_688412139bfc832c8bb41711706b0a18