### PR TITLE
Implement FastAPI backend with streaming

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . /app
+RUN pip install -r requirements-backend.txt && pip install -r requirements.txt
+CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+import asyncio
+from .solver_adapter import SolverAdapter
+
+app = FastAPI()
+solver = SolverAdapter()
+
+
+@app.post("/reset")
+async def reset() -> dict:
+    solver.reset()
+    return {"status": "ok"}
+
+
+@app.post("/params")
+async def params(particles: int | None = None,
+                 radius: float | None = None,
+                 dt: float | None = None,
+                 colour_mode: str | None = None) -> dict:
+    solver.set_params(particles, radius, dt, colour_mode)
+    return {"status": "ok"}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            solver.step()
+            await ws.send_bytes(solver.buffer())
+            await asyncio.sleep(solver.dt)
+    except WebSocketDisconnect:
+        pass

--- a/backend/solver_adapter.py
+++ b/backend/solver_adapter.py
@@ -1,0 +1,51 @@
+import numpy as np
+from core import Solver
+from generator import Generator
+from particle import VerletObject
+
+
+class SolverAdapter:
+    """Non-blocking wrapper around :class:`Solver`."""
+
+    def __init__(self, particles: int = 10, radius: float = 50.0, dt: float = 1/60, colour_mode: str = "velocity"):
+        self.particles = particles
+        self.radius = radius
+        self.dt = dt
+        self.colour_mode = colour_mode
+        self.solver = self._build_solver()
+
+    def _build_solver(self) -> Solver:
+        gen = Generator(VerletObject)
+        parts = list(gen.rnd_particle_gen(self.particles, self.radius))
+        if parts:
+            parts[0].fixated = True
+        solver = Solver(parts)
+        solver.dt = self.dt
+        solver.runtime = 0.0
+        return solver
+
+    def reset(self):
+        self.solver = self._build_solver()
+
+    def set_params(self, particles: int | None = None, radius: float | None = None,
+                   dt: float | None = None, colour_mode: str | None = None):
+        if particles is not None:
+            self.particles = particles
+        if radius is not None:
+            self.radius = radius
+        if dt is not None:
+            self.dt = dt
+        if colour_mode is not None:
+            self.colour_mode = colour_mode
+        self.reset()
+
+    def step(self):
+        self.solver.update()
+        self.solver.runtime += self.solver.dt
+
+    def buffer(self) -> bytes:
+        pos = self.solver.positions[:, 1]
+        rad = self.solver.radii
+        vel = self.solver.velocities[:, 1]
+        data = np.concatenate([pos, rad[:, None], vel], axis=1).astype(np.float32)
+        return data.tobytes()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,3 @@
+from solver import Solver
+
+__all__ = ["Solver"]

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+websockets
+httpx

--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uvicorn backend.app:app --reload

--- a/tests/test_backend_ws.py
+++ b/tests/test_backend_ws.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.app import app
+
+
+def test_backend_websocket():
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        data = ws.receive_bytes()
+        assert len(data) > 0
+        data2 = ws.receive_bytes()
+        assert len(data2) > 0
+


### PR DESCRIPTION
## Summary
- add FastAPI backend and websocket stream for particle data
- expose `reset` and `params` routes
- wrap `Solver` in an async adapter
- supply run script and dockerfile
- test websocket streaming

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-backend.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884128bc988832c8773d4c5fa81f9ad