### PR TITLE
Add interactive controls and loop

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,9 +1,15 @@
 import streamlit as st
 import matplotlib.pyplot as plt
 import numpy as np
+import time
 
 from simulation import setup_solver, animate_simulation, plot_kinetic_energy
-from utils.ui_state import init_state
+from utils.ui_state import (
+    init_state,
+    start_running,
+    stop_running,
+    reset_state,
+)
 
 canvas_slot = st.empty()
 
@@ -27,10 +33,59 @@ def build_sidebar():
         "frame_skip": st.sidebar.number_input(
             "Display every n-th frame", min_value=1, max_value=50, value=1, step=1
         ),
+        "speed": st.sidebar.slider(
+            "Speed multiplier", min_value=1.0, max_value=2.0, value=1.0, step=0.1
+        ),
         "run": st.sidebar.button("Run Simulation"),
         "live": st.sidebar.button("Live Demo"),
     }
+    with st.sidebar:
+        st.button("Play", on_click=start_running)
+        st.button("Pause", on_click=stop_running)
+        st.button("Reset", on_click=reset_state)
     return ui
+
+
+def run_loop_step(ui):
+    """Execute a single update-draw iteration."""
+    if "iter" not in st.session_state:
+        st.session_state["iter"] = st.session_state["solver"].run_simulation_iter(
+            ui["sim_time"], int(ui["substeps"])
+        )
+    try:
+        _, data = next(st.session_state["iter"])
+    except StopIteration:
+        stop_running()
+        return False
+
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.set_aspect("equal")
+    ax.set_facecolor("darkgray")
+    circle = plt.Circle(
+        (0, 0),
+        ui["bounding_box_radius"],
+        edgecolor="black",
+        facecolor="white",
+        fill=True,
+    )
+    ax.add_patch(circle)
+    fig.canvas.draw()
+    px_per_scale = (
+        ax.get_window_extent().width / (2 * ui["bounding_box_radius"] + 2) * 72.0 / fig.dpi
+    )
+    particles = np.vstack(data)
+    ax.scatter(
+        particles[:, 0],
+        particles[:, 1],
+        c=np.linalg.norm(particles[:, 6:8], axis=1),
+        cmap="gist_rainbow",
+        edgecolors="white",
+        s=(px_per_scale * 2 * particles[:, 7]) ** 2,
+        linewidth=0,
+    )
+    canvas_slot.pyplot(fig, clear_figure=True)
+    plt.close(fig)
+    return True
 
 
 def main():
@@ -63,37 +118,17 @@ def main():
         st.session_state["solver"] = setup_solver(
             ui["n_particles"], ui["bounding_box_radius"], ui["sim_time"], ui["substeps"]
         )
-        placeholder = canvas_slot
-        progress = st.progress(0.0)
-
-        fig, ax = plt.subplots(figsize=(5, 5))
-        ax.set_aspect("equal")
-        ax.set_facecolor("darkgray")
-        circle = plt.Circle(
-            (0, 0),
-            ui["bounding_box_radius"],
-            edgecolor="black",
-            facecolor="white",
-            fill=True,
+        st.session_state["iter"] = st.session_state["solver"].run_simulation_iter(
+            ui["sim_time"], int(ui["substeps"])
         )
-        ax.add_patch(circle)
-        fig.canvas.draw()
-        px_per_scale = (
-            ax.get_window_extent().width / (2 * ui["bounding_box_radius"] + 2) * 72.0 / fig.dpi
-        )
-        scatter = ax.scatter([], [], cmap="gist_rainbow", edgecolors="white", linewidth=0)
+        start_running()
 
-        for step, (_, data) in enumerate(
-            st.session_state["solver"].run_simulation_iter(ui["sim_time"], int(ui["substeps"]))
-        ):
-            particles = np.vstack(data)
-            if step % int(ui["frame_skip"]) == 0:
-                scatter.set_offsets(particles[:, :2])
-                scatter.set_array(np.linalg.norm(particles[:, 6:8], axis=1))
-                scatter.set_sizes((px_per_scale * 2 * particles[:, 7]) ** 2)
-                placeholder.pyplot(fig)
-            progress.progress((step + 1) / ui["substeps"])
-        plt.close(fig)
+    while st.session_state.get("running", False):
+        if not run_loop_step(ui):
+            break
+
+        time.sleep(ui["speed"] / 60)
+        st.experimental_rerun()
 
 
 if __name__ == "__main__":

--- a/tests/test_streamlit_speed.py
+++ b/tests/test_streamlit_speed.py
@@ -1,0 +1,23 @@
+import streamlit as st
+import simulation
+from streamlit_app import run_loop_step
+from utils.ui_state import init_state
+
+
+def test_streamlit_loop_advances_time():
+    st.session_state.clear()
+    init_state()
+    solver = simulation.setup_solver(n_particles=1, bounding_box_radius=10, time=0.2, substeps=2)
+    st.session_state['solver'] = solver
+    st.session_state['running'] = True
+    ui = {
+        'sim_time': 0.2,
+        'substeps': 2,
+        'bounding_box_radius': 10,
+        'speed': 1.0,
+    }
+    st.session_state['iter'] = solver.run_simulation_iter(ui['sim_time'], int(ui['substeps']))
+    before = solver.runtime
+    run_loop_step(ui)
+    after = solver.runtime
+    assert after > before

--- a/utils/ui_state.py
+++ b/utils/ui_state.py
@@ -16,3 +16,13 @@ def reset_state():
 def toggle_running():
     """Toggle the running flag."""
     st.session_state["running"] = not st.session_state.get("running", False)
+
+
+def start_running():
+    """Set running flag to True."""
+    st.session_state["running"] = True
+
+
+def stop_running():
+    """Set running flag to False."""
+    st.session_state["running"] = False


### PR DESCRIPTION
## Summary
- add play/pause/reset callbacks
- implement main animation loop for Streamlit demo
- expose `run_loop_step` helper for tests
- ensure interactive loop advances solver time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688413b686dc832c8389bc6e70858941