### PR TITLE
Add sidebar controls and metrics

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,19 @@
 import ParticleCanvas from './components/ParticleCanvas';
+import ControlPanel from './components/ControlPanel';
+import Metrics from './components/Metrics';
 
 export default function App() {
   return (
-    <div className="h-full w-full">
-      <ParticleCanvas />
+    <div className="h-full w-full flex flex-col md:flex-row">
+      <aside className="bg-gray-900 text-white p-2 w-full md:w-64">
+        <ControlPanel />
+        <div className="mt-4">
+          <Metrics />
+        </div>
+      </aside>
+      <main className="flex-1 relative">
+        <ParticleCanvas />
+      </main>
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,29 @@
+const BASE = (import.meta.env.VITE_API_URL as string) || 'http://localhost:8000';
+
+export async function post(path: string, body: Record<string, unknown>) {
+  const res = await fetch(new URL(path, BASE).toString(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
+export function connectWs(path: string, onMessage: (ev: MessageEvent) => void) {
+  let ws: WebSocket;
+  function connect() {
+    const url = new URL(path, BASE);
+    url.protocol = url.protocol.replace('http', 'ws');
+    ws = new WebSocket(url.toString());
+    ws.binaryType = 'arraybuffer';
+    ws.onmessage = onMessage;
+    ws.onclose = () => {
+      setTimeout(connect, 1000);
+    };
+  }
+  connect();
+  return ws;
+}

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -1,0 +1,82 @@
+import { post } from '../api';
+import { useSimStore } from '../store/useSimStore';
+
+export default function ControlPanel() {
+  const {
+    running,
+    speed,
+    particleCount,
+    radius,
+    colourMode,
+    setRunning,
+    setSpeed,
+    setParticleCount,
+    setRadius,
+    setColourMode,
+  } = useSimStore();
+
+  const toggle = () => setRunning(!running);
+  const reset = () => post('/reset', {});
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={toggle}
+          className="px-2 py-1 rounded bg-blue-600 text-white"
+        >
+          {running ? 'Pause' : 'Play'}
+        </button>
+        <button
+          onClick={reset}
+          className="px-2 py-1 rounded bg-gray-500 text-white"
+        >
+          Reset
+        </button>
+      </div>
+      <div>
+        <label className="block">Speed {speed.toFixed(3)}</label>
+        <input
+          type="range"
+          min="0.001"
+          max="0.1"
+          step="0.001"
+          value={speed}
+          onChange={(e) => setSpeed(parseFloat(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block">Particles {particleCount}</label>
+        <input
+          type="range"
+          min="10"
+          max="2000"
+          step="10"
+          value={particleCount}
+          onChange={(e) => setParticleCount(parseInt(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block">Radius {radius}</label>
+        <input
+          type="range"
+          min="10"
+          max="200"
+          step="1"
+          value={radius}
+          onChange={(e) => setRadius(parseInt(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block">Colour</label>
+        <select
+          className="w-full border p-1"
+          value={colourMode}
+          onChange={(e) => setColourMode(e.target.value)}
+        >
+          <option value="velocity">Velocity</option>
+          <option value="id">Id</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Metrics.tsx
+++ b/frontend/src/components/Metrics.tsx
@@ -1,0 +1,12 @@
+import { useSimStore } from '../store/useSimStore';
+
+export default function Metrics() {
+  const fps = useSimStore((s) => s.fps);
+  const energy = useSimStore((s) => s.energy);
+  return (
+    <div className="text-sm space-y-1">
+      <div>FPS: {fps.toFixed(1)}</div>
+      <div>Energy: {energy.toFixed(2)}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/ParticleCanvas.tsx
+++ b/frontend/src/components/ParticleCanvas.tsx
@@ -1,44 +1,85 @@
 import { useEffect, useRef } from 'react';
 import { Graphics, Application } from 'pixi.js';
-
-const WS_PATH = '/ws';
+import { connectWs, post } from '../api';
+import { useSimStore } from '../store/useSimStore';
 
 export default function ParticleCanvas() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const appRef = useRef<Application>();
+  const wsRef = useRef<WebSocket | null>(null);
+  const last = useRef<number>(performance.now());
+
+  const running = useSimStore((s) => s.running);
+  const speed = useSimStore((s) => s.speed);
+  const particleCount = useSimStore((s) => s.particleCount);
+  const radius = useSimStore((s) => s.radius);
+  const colourMode = useSimStore((s) => s.colourMode);
+  const setFps = useSimStore((s) => s.setFps);
+  const setEnergy = useSimStore((s) => s.setEnergy);
+
+  useEffect(() => {
+    post('/params', {
+      particles: particleCount,
+      radius,
+      dt: speed,
+      colour_mode: colourMode,
+    }).catch(() => {});
+  }, [particleCount, radius, speed, colourMode]);
 
   useEffect(() => {
     const app = new Application({
       resizeTo: containerRef.current ?? undefined,
       backgroundAlpha: 0,
     });
+    appRef.current = app;
     const target = containerRef.current;
-    if (!target) return;
-    target.appendChild(app.view as HTMLCanvasElement);
-
-    const base = (import.meta.env.VITE_API_URL as string) || 'http://localhost:8000';
-    const wsUrl = new URL(WS_PATH, base);
-    wsUrl.protocol = wsUrl.protocol.replace('http', 'ws');
-    const ws = new WebSocket(wsUrl.toString());
-
-    ws.binaryType = 'arraybuffer';
-
-    ws.onmessage = (ev) => {
-      const arr = new Float32Array(ev.data);
-      app.stage.removeChildren();
-      for (let i = 0; i < arr.length; i += 2) {
-        const g = new Graphics();
-        g.beginFill(0xffffff);
-        g.drawCircle(arr[i], arr[i + 1], 3);
-        g.endFill();
-        app.stage.addChild(g);
-      }
-    };
-
+    if (target) {
+      target.appendChild(app.view as HTMLCanvasElement);
+    }
     return () => {
-      ws.close();
+      wsRef.current?.close();
       app.destroy(true);
     };
   }, []);
+
+  useEffect(() => {
+    const app = appRef.current;
+    if (!app) return;
+
+    const handle = (ev: MessageEvent) => {
+      const arr = new Float32Array(ev.data);
+      app.stage.removeChildren();
+      let energy = 0;
+      for (let i = 0; i < arr.length; i += 5) {
+        const x = arr[i];
+        const y = arr[i + 1];
+        const r = arr[i + 2];
+        const vx = arr[i + 3];
+        const vy = arr[i + 4];
+        energy += 0.5 * (vx * vx + vy * vy);
+        const g = new Graphics();
+        g.beginFill(0xffffff);
+        g.drawCircle(x, y, r);
+        g.endFill();
+        app.stage.addChild(g);
+      }
+      const now = performance.now();
+      setFps(1000 / (now - last.current));
+      last.current = now;
+      setEnergy(energy);
+    };
+
+    if (running) {
+      wsRef.current = connectWs('/ws', handle);
+    } else {
+      wsRef.current?.close();
+      wsRef.current = null;
+    }
+
+    return () => {
+      wsRef.current?.close();
+    };
+  }, [running]);
 
   return <div ref={containerRef} className="h-full w-full" />;
 }

--- a/frontend/src/store/useSimStore.ts
+++ b/frontend/src/store/useSimStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+export interface SimState {
+  running: boolean;
+  speed: number;
+  particleCount: number;
+  radius: number;
+  colourMode: string;
+  fps: number;
+  energy: number;
+  setRunning: (v: boolean) => void;
+  setSpeed: (v: number) => void;
+  setParticleCount: (v: number) => void;
+  setRadius: (v: number) => void;
+  setColourMode: (v: string) => void;
+  setFps: (v: number) => void;
+  setEnergy: (v: number) => void;
+}
+
+export const useSimStore = create<SimState>((set) => ({
+  running: false,
+  speed: 1 / 60,
+  particleCount: 100,
+  radius: 50,
+  colourMode: 'velocity',
+  fps: 0,
+  energy: 0,
+  setRunning: (v) => set({ running: v }),
+  setSpeed: (v) => set({ speed: v }),
+  setParticleCount: (v) => set({ particleCount: v }),
+  setRadius: (v) => set({ radius: v }),
+  setColourMode: (v) => set({ colourMode: v }),
+  setFps: (v) => set({ fps: v }),
+  setEnergy: (v) => set({ energy: v }),
+}));


### PR DESCRIPTION
## Summary
- state management via Zustand store
- new ControlPanel and Metrics components
- websocket reconnect logic and REST helper
- render sidebar HUD and canvas
- send params and track fps/energy in ParticleCanvas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841643a6cc832c8afea6b2dd7de183