### PR TITLE
Fix streamlit rerun call

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,6 +14,14 @@ from utils.ui_state import (
 canvas_slot = st.empty()
 
 
+def maybe_rerun():
+    """Call Streamlit's rerun function under any API name."""
+    if hasattr(st, "experimental_rerun"):
+        st.experimental_rerun()
+    else:
+        st.rerun()
+
+
 def build_sidebar():
     """Return a dictionary with sidebar widget values."""
     st.sidebar.header("Simulation Parameters")
@@ -128,7 +136,7 @@ def main():
             break
 
         time.sleep(ui["speed"] / 60)
-        st.experimental_rerun()
+        maybe_rerun()
 
 
 if __name__ == "__main__":

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,0 +1,26 @@
+import types
+import streamlit_app
+
+
+def test_maybe_rerun_experimental(monkeypatch):
+    called = {}
+
+    def exp():
+        called['exp'] = True
+
+    stub = types.SimpleNamespace(experimental_rerun=exp)
+    monkeypatch.setattr(streamlit_app, "st", stub)
+    streamlit_app.maybe_rerun()
+    assert called.get('exp', False)
+
+
+def test_maybe_rerun_new(monkeypatch):
+    called = {}
+
+    def new():
+        called['rerun'] = True
+
+    stub = types.SimpleNamespace(rerun=new)
+    monkeypatch.setattr(streamlit_app, "st", stub)
+    streamlit_app.maybe_rerun()
+    assert called.get('rerun', False)


### PR DESCRIPTION
## Summary
- support both `experimental_rerun` and `rerun` in Streamlit
- add regression tests for `maybe_rerun`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841c1f1a68832cb57769a77ed60015