### PR TITLE
Fix streamlit rerun call

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -11,7 +11,14 @@ from utils.ui_state import (
     reset_state,
 )
 
-canvas_slot = st.empty()
+
+
+def maybe_rerun():
+    """Call Streamlit's rerun function under any API name."""
+    if hasattr(st, "experimental_rerun"):
+        st.experimental_rerun()
+    else:
+        st.rerun()
 
 
 def build_sidebar():
@@ -52,39 +59,37 @@ def run_loop_step(ui):
         st.session_state["iter"] = st.session_state["solver"].run_simulation_iter(
             ui["sim_time"], int(ui["substeps"])
         )
+
     try:
         _, data = next(st.session_state["iter"])
     except StopIteration:
         stop_running()
         return False
 
-    fig, ax = plt.subplots(figsize=(5, 5))
-    ax.set_aspect("equal")
-    ax.set_facecolor("darkgray")
-    circle = plt.Circle(
-        (0, 0),
-        ui["bounding_box_radius"],
-        edgecolor="black",
-        facecolor="white",
-        fill=True,
-    )
-    ax.add_patch(circle)
+    if st.session_state.get("fig_ax_scatter") is None:
+        fig, ax = plt.subplots(figsize=(5, 5))
+        ax.set_aspect("equal")
+        ax.set_facecolor("darkgray")
+        circle = plt.Circle(
+            (0, 0),
+            ui["bounding_box_radius"],
+            edgecolor="black",
+            facecolor="white",
+            fill=True,
+        )
+        ax.add_patch(circle)
+        scatter = ax.scatter([], [], cmap="gist_rainbow", edgecolors="white", linewidth=0)
+        st.session_state["fig_ax_scatter"] = (fig, ax, scatter)
+    fig, ax, scatter = st.session_state["fig_ax_scatter"]
     fig.canvas.draw()
     px_per_scale = (
         ax.get_window_extent().width / (2 * ui["bounding_box_radius"] + 2) * 72.0 / fig.dpi
     )
     particles = np.vstack(data)
-    ax.scatter(
-        particles[:, 0],
-        particles[:, 1],
-        c=np.linalg.norm(particles[:, 6:8], axis=1),
-        cmap="gist_rainbow",
-        edgecolors="white",
-        s=(px_per_scale * 2 * particles[:, 7]) ** 2,
-        linewidth=0,
-    )
-    canvas_slot.pyplot(fig, clear_figure=True)
-    plt.close(fig)
+    scatter.set_offsets(particles[:, :2])
+    scatter.set_array(np.linalg.norm(particles[:, 6:8], axis=1))
+    scatter.set_sizes((px_per_scale * 2 * particles[:, 7]) ** 2)
+    st.session_state["canvas_slot"].pyplot(fig)
     return True
 
 
@@ -128,7 +133,7 @@ def main():
             break
 
         time.sleep(ui["speed"] / 60)
-        st.experimental_rerun()
+        maybe_rerun()
 
 
 if __name__ == "__main__":

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,0 +1,26 @@
+import types
+import streamlit_app
+
+
+def test_maybe_rerun_experimental(monkeypatch):
+    called = {}
+
+    def exp():
+        called['exp'] = True
+
+    stub = types.SimpleNamespace(experimental_rerun=exp)
+    monkeypatch.setattr(streamlit_app, "st", stub)
+    streamlit_app.maybe_rerun()
+    assert called.get('exp', False)
+
+
+def test_maybe_rerun_new(monkeypatch):
+    called = {}
+
+    def new():
+        called['rerun'] = True
+
+    stub = types.SimpleNamespace(rerun=new)
+    monkeypatch.setattr(streamlit_app, "st", stub)
+    streamlit_app.maybe_rerun()
+    assert called.get('rerun', False)

--- a/utils/ui_state.py
+++ b/utils/ui_state.py
@@ -5,12 +5,20 @@ def init_state():
     """Initialize session_state variables used by the UI."""
     st.session_state.setdefault("running", False)
     st.session_state.setdefault("solver", None)
+    st.session_state.setdefault("canvas_slot", st.empty())
+    st.session_state.setdefault("fig_ax_scatter", None)
 
 
 def reset_state():
     """Reset solver and running flag."""
     st.session_state["solver"] = None
     st.session_state["running"] = False
+    if st.session_state.get("fig_ax_scatter"):
+        import matplotlib.pyplot as plt
+
+        plt.close(st.session_state["fig_ax_scatter"][0])
+    st.session_state["fig_ax_scatter"] = None
+    st.session_state["canvas_slot"] = st.empty()
 
 
 def toggle_running():


### PR DESCRIPTION
## Summary
- support both `experimental_rerun` and `rerun` in Streamlit
- add regression tests for `maybe_rerun`
- persist the figure between reruns so the canvas no longer flashes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68841c1f1a68832cb57769a77ed60015